### PR TITLE
Add Trove classifiers for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,14 @@ setup(
     author_email='tom.dalton@fanduel.com',
     install_requires=[
         'datadog==0.16.0',
-    ]
+    ],
+    classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
 )


### PR DESCRIPTION
These would help understanding from a glance what Python versions are
supported by fdjangodog and it they are also used by tools such as
caniusepython3, which relies on trove classifiers to figure out if a
library supports Python 3 or not.

I added classifiers for versions supported in tox.ini.