### PR TITLE
Relax datadog pin to >=0.16.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author='Tom Dalton',
     author_email='tom.dalton@fanduel.com',
     install_requires=[
-        'datadog==0.16.0',
+        'datadog>=0.16.0',
     ],
     classifiers=[
         'Programming Language :: Python',


### PR DESCRIPTION
Relax datadog pin so it is more lenient to library users when they are using pip 20.x 